### PR TITLE
Update Nextcloud setup

### DIFF
--- a/DOC.md
+++ b/DOC.md
@@ -11,13 +11,13 @@ sudo fdisk -l
 Go into `fdisk` and create the partition:
 
 ```bash
-sudo fdisk /dev/sdb
+sudo fdisk /dev/sda
 ```
 
 Once you have the partition, format it:
 
 ```bash
-sudo mkfs.ext4 /dev/sdb1
+sudo mkfs.ext4 /dev/sda1
 ```
 
 ## Set up WIFI for a Pi

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Current raspberries:
 
 1. Prepare Raspberry Pis
 
-   1. [Download](https://www.raspberrypi.com/software/) and [install](https://www.raspberrypi.org/documentation/installation/installing-images/mac.md) Raspbian Lite on Raspberry Pi
+   1. [Download](https://www.raspberrypi.com/software/) and [install](https://www.raspberrypi.com/documentation/computers/getting-started.html#installing-images-on-mac-os) Raspbian Lite on Raspberry Pi
 
    1. [Enable ssh](https://www.raspberrypi.org/documentation/remote-access/ssh/) by placing an empty `ssh` file in the `boot` directory of the disk
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Current raspberries:
 
 1. Prepare Raspberry Pis
 
-   1. [Download](https://www.raspberrypi.org/downloads/raspbian/) and [install](https://www.raspberrypi.org/documentation/installation/installing-images/mac.md) Raspbian Lite on Raspberry Pi
+   1. [Download](https://www.raspberrypi.com/software/) and [install](https://www.raspberrypi.org/documentation/installation/installing-images/mac.md) Raspbian Lite on Raspberry Pi
 
    1. [Enable ssh](https://www.raspberrypi.org/documentation/remote-access/ssh/) by placing an empty `ssh` file in the `boot` directory of the disk
 

--- a/roles/nextcloud/defaults/main.yml
+++ b/roles/nextcloud/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 nextcloud_com:
   releases_url: https://download.nextcloud.com/server/releases/nextcloud
-  version: 19.0.6
-php_version: '7.3'
+  version: 23.0.2
+php_version: '7.4'

--- a/roles/nextcloud/handlers/main.yml
+++ b/roles/nextcloud/handlers/main.yml
@@ -14,6 +14,12 @@
     state: reloaded
   become: yes
 
+- name: restart nginx
+  service:
+    name: nginx
+    state: restarted
+  become: yes
+
 - name: restart php-fpm
   service:
     name: 'php{{ php_version }}-fpm'

--- a/roles/nextcloud/handlers/main.yml
+++ b/roles/nextcloud/handlers/main.yml
@@ -25,3 +25,9 @@
     name: 'php{{ php_version }}-fpm'
     state: restarted
   become: yes
+
+- name: restart postgres
+  service:
+    name: postgresql
+    state: restarted
+  become: yes

--- a/roles/nextcloud/tasks/cron.yml
+++ b/roles/nextcloud/tasks/cron.yml
@@ -1,4 +1,15 @@
 ---
+- name: Enable APCu for Nextcloud cron jobs
+  ini_file:
+    path: '/etc/php/{{ php_version }}/mods-available/apcu.ini'
+    section: ''
+    option: apc.enable_cli
+    value: 1
+  become: yes
+  notify:
+    - restart nginx
+  tags: [nextcloud, cron, php]
+
 - name: add nextcloud cron service
   template:
     src: systemd/nextcloudcron.service.j2

--- a/roles/nextcloud/tasks/nginx.yml
+++ b/roles/nextcloud/tasks/nginx.yml
@@ -27,4 +27,5 @@
   template:
     src: nginx/default.config.j2
     dest: /etc/nginx/sites-available/default
+  become: yes
   tags: [nextcloud, nginx]

--- a/roles/nextcloud/tasks/packages.yml
+++ b/roles/nextcloud/tasks/packages.yml
@@ -9,6 +9,7 @@
       - curl
       - libcurl4
       - ffmpeg
+      - libmagickcore-6.q16-3-extra
   become: yes
   tags: [nextcloud, packages]
 

--- a/roles/nextcloud/tasks/postgres.yml
+++ b/roles/nextcloud/tasks/postgres.yml
@@ -1,5 +1,42 @@
 ---
-- name: change password for postgres user
+- name: Collect Postgres version
+  postgresql_info:
+    filter: ver*
+  register: postgres_info_result
+  become: yes
+  tags: [nextcloud, postgres]
+
+- name: Debug Postgres version
+  debug:
+    msg: 'Running Postgres version: {{ postgres_info_result.version.major }}'
+  tags: [nextcloud, postgres]
+  when: postgres_info_result.version.major is defined
+
+- name: Set postgres user authentication method to md5
+  postgresql_pg_hba:
+    dest: '/etc/postgresql/{{ postgres_info_result.version.major }}/main/pg_hba.conf'
+    contype: local
+    databases: all
+    users: postgres
+    method: md5
+  become: yes
+  notify:
+    - restart postges
+  tags: [nextcloud, postgres]
+
+- name: Set all user authentication method to md5
+  postgresql_pg_hba:
+    dest: '/etc/postgresql/{{ postgres_info_result.version.major }}/main/pg_hba.conf'
+    contype: local
+    databases: all
+    users: all
+    method: md5
+  become: yes
+  notify:
+    - restart postges
+  tags: [nextcloud, postgres]
+
+- name: Change password for postgres user
   postgresql_user:
     db: postgres
     user: postgres
@@ -10,7 +47,7 @@
     ansible_ssh_pipelining: true
   tags: [nextcloud, postgres]
 
-- name: create nextcloud database user
+- name: Create user for Nextcloud database
   postgresql_user:
     user: '{{ postgres.nextcloud.db_user }}'
     password: '{{ postgres.nextcloud.db_password }}'
@@ -21,7 +58,7 @@
     ansible_ssh_pipelining: true
   tags: [nextcloud, postgres]
 
-- name: create nextcloud database
+- name: Create database for Nextcloud
   postgresql_db:
     name: '{{ postgres.nextcloud.db_name }}'
     owner: '{{ postgres.nextcloud.db_user }}'
@@ -30,4 +67,3 @@
   vars:
     ansible_ssh_pipelining: true
   tags: [nextcloud, postgres]
-

--- a/roles/nextcloud/tasks/postgres.yml
+++ b/roles/nextcloud/tasks/postgres.yml
@@ -1,5 +1,5 @@
 ---
-- name: Collect Postgres version
+- name: Retrieve Postgres version
   postgresql_info:
     filter: ver*
   register: postgres_info_result

--- a/roles/nextcloud/templates/nginx/nextcloud.config.j2
+++ b/roles/nextcloud/templates/nginx/nextcloud.config.j2
@@ -22,51 +22,13 @@ server {
     ssl_certificate /etc/letsencrypt/live/{{ pi.domain }}/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/{{ pi.domain }}/privkey.pem;
 
-    # Add headers to serve security related headers
-    # Before enabling Strict-Transport-Security headers please read into this
-    # topic first.
-    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
-    #
+    # HSTS settings
     # WARNING: Only add the preload option once you read about
     # the consequences in https://hstspreload.org/. This option
     # will add the domain to a hardcoded list that is shipped
     # in all major browsers and getting removed from this list
     # could take several months.
-    add_header Referrer-Policy "no-referrer" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Download-Options "noopen" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Permitted-Cross-Domain-Policies "none" always;
-    add_header X-Robots-Tag "none" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-
-    # Remove X-Powered-By, which is an information leak
-    fastcgi_hide_header X-Powered-By;
-
-    # Path to the root of your installation
-    root /var/www/nextcloud;
-
-    location = /robots.txt {
-        allow all;
-        log_not_found off;
-        access_log off;
-    }
-
-    # The following 2 rules are only needed for the user_webfinger app.
-    # Uncomment it if you're planning to use this app.
-    #rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-    #rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-
-    # The following rule is only needed for the Social app.
-    # Uncomment it if you're planning to use this app.
-    #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
-
-    location = /.well-known/carddav {
-      return 301 $scheme://$host:$server_port/remote.php/dav;
-    }
-    location = /.well-known/caldav {
-      return 301 $scheme://$host:$server_port/remote.php/dav;
-    }
+    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;" always;
 
     # set max upload size
     client_max_body_size 16G;
@@ -84,74 +46,118 @@ server {
     gzip_comp_level 4;
     gzip_min_length 256;
     gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
-    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/wasm application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
-    # Uncomment if your server is build with the ngx_pagespeed module
-    # This module is currently not supported.
+    # Pagespeed is not supported by Nextcloud, so if your server is built
+    # with the `ngx_pagespeed` module, uncomment this line to disable it.
     #pagespeed off;
 
-    location / {
-        rewrite ^ /index.php;
+    # HTTP response headers borrowed from Nextcloud `.htaccess`
+    add_header Referrer-Policy                      "no-referrer"   always;
+    add_header X-Content-Type-Options               "nosniff"       always;
+    add_header X-Download-Options                   "noopen"        always;
+    add_header X-Frame-Options                      "SAMEORIGIN"    always;
+    add_header X-Permitted-Cross-Domain-Policies    "none"          always;
+    add_header X-Robots-Tag                         "none"          always;
+    add_header X-XSS-Protection                     "1; mode=block" always;
+
+    # Remove X-Powered-By, which is an information leak
+    fastcgi_hide_header X-Powered-By;
+
+    # Path to the root of your installation
+    root /var/www/nextcloud;
+
+    # Specify how to handle directories -- specifying `/index.php$request_uri`
+    # here as the fallback means that Nginx always exhibits the desired behaviour
+    # when a client requests a path that corresponds to a directory that exists
+    # on the server. In particular, if that directory contains an index.php file,
+    # that file is correctly served; if it doesn't, then the request is passed to
+    # the front-end controller. This consistent behaviour means that we don't need
+    # to specify custom rules for certain paths (e.g. images and other assets,
+    # `/updater`, `/ocm-provider`, `/ocs-provider`), and thus
+    # `try_files $uri $uri/ /index.php$request_uri`
+    # always provides the desired behaviour.
+    index index.php index.html /index.php$request_uri;
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
     }
 
-    location ~ ^\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
-        deny all;
-    }
-    location ~ ^\/(?:\.|autotest|occ|issue|indie|db_|console) {
-        deny all;
+    # Make a regex exception for `/.well-known` so that clients can still
+    # access it despite the existence of the regex rule
+    # `location ~ /(\.|autotest|...)` which would otherwise handle requests
+    # for `/.well-known`.
+    location ^~ /.well-known {
+        # The rules in this block are an adaptation of the rules
+        # in `.htaccess` that concern `/.well-known`.
+
+        location = /.well-known/carddav { return 301 /remote.php/dav/; }
+        location = /.well-known/caldav  { return 301 /remote.php/dav/; }
+
+        location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
+        location /.well-known/pki-validation    { try_files $uri $uri/ =404; }
+
+        # Let Nextcloud's API for `/.well-known` URIs handle all other
+        # requests by passing them to the front-end controller.
+        return 301 /index.php$request_uri;
     }
 
-    location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+)\.php(?:$|\/) {
-        fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
+    # Rules borrowed from `.htaccess` to hide certain paths from clients
+    location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)  { return 404; }
+    location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console)                { return 404; }
+
+    # Ensure this block, which passes PHP files to the PHP process, is above the blocks
+    # which handle static assets (as seen below). If this block is not declared first,
+    # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
+    # to the URI, resulting in a HTTP 500 error response.
+    location ~ \.php(?:$|/) {
+        # Required for legacy support
+        rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
+
+        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+        set $path_info $fastcgi_path_info;
+
         try_files $fastcgi_script_name =404;
+
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param PATH_INFO $path_info;
         fastcgi_param HTTPS on;
-        # Avoid sending the security headers twice
-        fastcgi_param modHeadersAvailable true;
-        # Enable pretty urls
-        fastcgi_param front_controller_active true;
+
+        fastcgi_param modHeadersAvailable true;         # Avoid sending the security headers twice
+        fastcgi_param front_controller_active true;     # Enable pretty urls
         fastcgi_pass php-handler;
+
         fastcgi_intercept_errors on;
+        fastcgi_request_buffering off;
+
+        fastcgi_max_temp_file_size 0;
     }
 
-    location ~ ^\/(?:updater|oc[ms]-provider)(?:$|\/) {
-        try_files $uri/ =404;
-        index index.php;
-    }
-
-    # Adding the cache control header for js, css and map files
-    # Make sure it is BELOW the PHP block
-    location ~ \.(?:css|js|woff2?|svg|gif|map)$ {
+    location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite)$ {
         try_files $uri /index.php$request_uri;
-        add_header Cache-Control "public, max-age=15778463";
-        # Add headers to serve security related headers (It is intended to
-        # have those duplicated to the ones above)
-        # Before enabling Strict-Transport-Security headers please read into
-        # this topic first.
-        #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
-        #
-        # WARNING: Only add the preload option once you read about
-        # the consequences in https://hstspreload.org/. This option
-        # will add the domain to a hardcoded list that is shipped
-        # in all major browsers and getting removed from this list
-        # could take several months.
-        add_header Referrer-Policy "no-referrer" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Download-Options "noopen" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Permitted-Cross-Domain-Policies "none" always;
-        add_header X-Robots-Tag "none" always;
-        add_header X-XSS-Protection "1; mode=block" always;
+        expires 6M;         # Cache-Control policy borrowed from `.htaccess`
+        access_log off;     # Optional: Don't log access to assets
 
-        # Optional: Don't log access to assets
-        access_log off;
+        location ~ \.wasm$ {
+            default_type application/wasm;
+        }
     }
 
-    location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap)$ {
+    location ~ \.woff2?$ {
         try_files $uri /index.php$request_uri;
-        # Optional: Don't log access to other assets
-        access_log off;
+        expires 7d;         # Cache-Control policy borrowed from `.htaccess`
+        access_log off;     # Optional: Don't log access to assets
+    }
+
+    # Rule borrowed from `.htaccess`
+    location /remote {
+        return 301 /remote.php$request_uri;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php$request_uri;
     }
 }

--- a/roles/nextcloud/templates/nginx/nextcloud_http.config.j2
+++ b/roles/nextcloud/templates/nginx/nextcloud_http.config.j2
@@ -8,47 +8,6 @@ server {
     listen [::]:80;
     server_name localhost;
 
-    # WARNING: Only add the preload option once you read about
-    # the consequences in https://hstspreload.org/. This option
-    # will add the domain to a hardcoded list that is shipped
-    # in all major browsers and getting removed from this list
-    # could take several months.
-    add_header Referrer-Policy "no-referrer" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-Download-Options "noopen" always;
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Permitted-Cross-Domain-Policies "none" always;
-    add_header X-Robots-Tag "none" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-
-    # Remove X-Powered-By, which is an information leak
-    fastcgi_hide_header X-Powered-By;
-
-    # Path to the root of your installation
-    root /var/www/nextcloud;
-
-    location = /robots.txt {
-        allow all;
-        log_not_found off;
-        access_log off;
-    }
-
-    # The following 2 rules are only needed for the user_webfinger app.
-    # Uncomment it if you're planning to use this app.
-    #rewrite ^/.well-known/host-meta /public.php?service=host-meta last;
-    #rewrite ^/.well-known/host-meta.json /public.php?service=host-meta-json last;
-
-    # The following rule is only needed for the Social app.
-    # Uncomment it if you're planning to use this app.
-    #rewrite ^/.well-known/webfinger /public.php?service=webfinger last;
-
-    location = /.well-known/carddav {
-      return 301 $scheme://$host:$server_port/remote.php/dav;
-    }
-    location = /.well-known/caldav {
-      return 301 $scheme://$host:$server_port/remote.php/dav;
-    }
-
     # set max upload size
     client_max_body_size 16G;
     fastcgi_buffers 64 4K;
@@ -65,74 +24,114 @@ server {
     gzip_comp_level 4;
     gzip_min_length 256;
     gzip_proxied expired no-cache no-store private no_last_modified no_etag auth;
-    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
+    gzip_types application/atom+xml application/javascript application/json application/ld+json application/manifest+json application/rss+xml application/vnd.geo+json application/vnd.ms-fontobject application/wasm application/x-font-ttf application/x-web-app-manifest+json application/xhtml+xml application/xml font/opentype image/bmp image/svg+xml image/x-icon text/cache-manifest text/css text/plain text/vcard text/vnd.rim.location.xloc text/vtt text/x-component text/x-cross-domain-policy;
 
-    # Uncomment if your server is build with the ngx_pagespeed module
-    # This module is currently not supported.
-    #pagespeed off;
+    # HTTP response headers borrowed from Nextcloud `.htaccess`
+    add_header Referrer-Policy                      "no-referrer"   always;
+    add_header X-Content-Type-Options               "nosniff"       always;
+    add_header X-Download-Options                   "noopen"        always;
+    add_header X-Frame-Options                      "SAMEORIGIN"    always;
+    add_header X-Permitted-Cross-Domain-Policies    "none"          always;
+    add_header X-Robots-Tag                         "none"          always;
+    add_header X-XSS-Protection                     "1; mode=block" always;
 
-    location / {
-        rewrite ^ /index.php;
+    # Remove X-Powered-By, which is an information leak
+    fastcgi_hide_header X-Powered-By;
+
+    # Path to the root of your installation
+    root /var/www/nextcloud;
+
+    # Specify how to handle directories -- specifying `/index.php$request_uri`
+    # here as the fallback means that Nginx always exhibits the desired behaviour
+    # when a client requests a path that corresponds to a directory that exists
+    # on the server. In particular, if that directory contains an index.php file,
+    # that file is correctly served; if it doesn't, then the request is passed to
+    # the front-end controller. This consistent behaviour means that we don't need
+    # to specify custom rules for certain paths (e.g. images and other assets,
+    # `/updater`, `/ocm-provider`, `/ocs-provider`), and thus
+    # `try_files $uri $uri/ /index.php$request_uri`
+    # always provides the desired behaviour.
+    index index.php index.html /index.php$request_uri;
+
+    location = /robots.txt {
+        allow all;
+        log_not_found off;
+        access_log off;
     }
 
-    location ~ ^\/(?:build|tests|config|lib|3rdparty|templates|data)\/ {
-        deny all;
-    }
-    location ~ ^\/(?:\.|autotest|occ|issue|indie|db_|console) {
-        deny all;
+    # Make a regex exception for `/.well-known` so that clients can still
+    # access it despite the existence of the regex rule
+    # `location ~ /(\.|autotest|...)` which would otherwise handle requests
+    # for `/.well-known`.
+    location ^~ /.well-known {
+        # The rules in this block are an adaptation of the rules
+        # in `.htaccess` that concern `/.well-known`.
+
+        location = /.well-known/carddav { return 301 /remote.php/dav/; }
+        location = /.well-known/caldav  { return 301 /remote.php/dav/; }
+
+        location /.well-known/acme-challenge    { try_files $uri $uri/ =404; }
+        location /.well-known/pki-validation    { try_files $uri $uri/ =404; }
+
+        # Let Nextcloud's API for `/.well-known` URIs handle all other
+        # requests by passing them to the front-end controller.
+        return 301 /index.php$request_uri;
     }
 
-    location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+)\.php(?:$|\/) {
-        fastcgi_split_path_info ^(.+?\.php)(\/.*|)$;
+    # Rules borrowed from `.htaccess` to hide certain paths from clients
+    location ~ ^/(?:build|tests|config|lib|3rdparty|templates|data)(?:$|/)  { return 404; }
+    location ~ ^/(?:\.|autotest|occ|issue|indie|db_|console)                { return 404; }
+
+    # Ensure this block, which passes PHP files to the PHP process, is above the blocks
+    # which handle static assets (as seen below). If this block is not declared first,
+    # then Nginx will encounter an infinite rewriting loop when it prepends `/index.php`
+    # to the URI, resulting in a HTTP 500 error response.
+    location ~ \.php(?:$|/) {
+        # Required for legacy support
+        rewrite ^/(?!index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+|.+\/richdocumentscode\/proxy) /index.php$request_uri;
+
+        fastcgi_split_path_info ^(.+?\.php)(/.*)$;
+        set $path_info $fastcgi_path_info;
+
         try_files $fastcgi_script_name =404;
+
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-        fastcgi_param PATH_INFO $fastcgi_path_info;
+        fastcgi_param PATH_INFO $path_info;
         fastcgi_param HTTPS on;
-        # Avoid sending the security headers twice
-        fastcgi_param modHeadersAvailable true;
-        # Enable pretty urls
-        fastcgi_param front_controller_active true;
+
+        fastcgi_param modHeadersAvailable true;         # Avoid sending the security headers twice
+        fastcgi_param front_controller_active true;     # Enable pretty urls
         fastcgi_pass php-handler;
+
         fastcgi_intercept_errors on;
+        fastcgi_request_buffering off;
+
+        fastcgi_max_temp_file_size 0;
     }
 
-    location ~ ^\/(?:updater|oc[ms]-provider)(?:$|\/) {
-        try_files $uri/ =404;
-        index index.php;
-    }
-
-    # Adding the cache control header for js, css and map files
-    # Make sure it is BELOW the PHP block
-    location ~ \.(?:css|js|woff2?|svg|gif|map)$ {
+    location ~ \.(?:css|js|svg|gif|png|jpg|ico|wasm|tflite)$ {
         try_files $uri /index.php$request_uri;
-        add_header Cache-Control "public, max-age=15778463";
-        # Add headers to serve security related headers (It is intended to
-        # have those duplicated to the ones above)
-        # Before enabling Strict-Transport-Security headers please read into
-        # this topic first.
-        #add_header Strict-Transport-Security "max-age=15768000; includeSubDomains; preload;";
-        #
-        # WARNING: Only add the preload option once you read about
-        # the consequences in https://hstspreload.org/. This option
-        # will add the domain to a hardcoded list that is shipped
-        # in all major browsers and getting removed from this list
-        # could take several months.
-        add_header Referrer-Policy "no-referrer" always;
-        add_header X-Content-Type-Options "nosniff" always;
-        add_header X-Download-Options "noopen" always;
-        add_header X-Frame-Options "SAMEORIGIN" always;
-        add_header X-Permitted-Cross-Domain-Policies "none" always;
-        add_header X-Robots-Tag "none" always;
-        add_header X-XSS-Protection "1; mode=block" always;
+        expires 6M;         # Cache-Control policy borrowed from `.htaccess`
+        access_log off;     # Optional: Don't log access to assets
 
-        # Optional: Don't log access to assets
-        access_log off;
+        location ~ \.wasm$ {
+            default_type application/wasm;
+        }
     }
 
-    location ~ \.(?:png|html|ttf|ico|jpg|jpeg|bcmap)$ {
+    location ~ \.woff2?$ {
         try_files $uri /index.php$request_uri;
-        # Optional: Don't log access to other assets
-        access_log off;
+        expires 7d;         # Cache-Control policy borrowed from `.htaccess`
+        access_log off;     # Optional: Don't log access to assets
+    }
+
+    # Rule borrowed from `.htaccess`
+    location /remote {
+        return 301 /remote.php$request_uri;
+    }
+
+    location / {
+        try_files $uri $uri/ /index.php$request_uri;
     }
 }


### PR DESCRIPTION
While setting up a new Nextcloud on my Pi with the new [64-bit OS](https://www.raspberrypi.com/software/operating-systems/), I tweaked some settings and configs here and there (mostly related to the updated versions).

Changes:
- Enable APCu on PHP CLI
  This is necessary for Nextcloud's periodic Cron jobs to run succesfully.
  See: https://docs.nextcloud.com/server/21/admin_manual/configuration_server/caching_configuration.html#id1
- Update PHP and Nextcloud versions
- Update Postgres role
  Add missing configuration for Postgres.
- Fix NGINX role: Add missing root access for moving NGINX files
- Update NGINX config
  Mostly just: https://docs.nextcloud.com/server/23/admin_manual/installation/nginx.html